### PR TITLE
Switch "night_mode" css class out for "anki_redesign"

### DIFF
--- a/9990000999/css_class.py
+++ b/9990000999/css_class.py
@@ -1,29 +1,29 @@
 def inject_css_class(state: bool, html: str):
     if state:
         javascript = """
-            function add_night_mode_class(){
+            function add_anki_redesign_class(){
                 current_classes = document.body.className;
-                if(current_classes.indexOf("night_mode") == -1)
+                if(current_classes.indexOf("anki_redesign") == -1)
                 {
-                    document.body.className += " night_mode";
+                    document.body.className += " anki_redesign";
                 }
             }
             // explanation of setTimeout use:
             // callback defined in _showQuestion of reviewer.js would otherwise overwrite
             // the newly set body class; in order to prevent that the function execution
             // is being placed on the end of execution queue (hence time = 0)
-            setTimeout(add_night_mode_class, 0)
+            setTimeout(add_anki_redesign_class, 0)
             """
     else:
         javascript = """
-            function remove_night_mode_class(){
+            function remove_anki_redesign_class(){
                 current_classes = document.body.className;
-                if(current_classes.indexOf("night_mode") != -1)
+                if(current_classes.indexOf("anki_redesign") != -1)
                 {
-                    document.body.className = current_classes.replace("night_mode","");
+                    document.body.className = current_classes.replace("anki_redesign","");
                 }
             }
-            setTimeout(remove_night_mode_class, 0)
+            setTimeout(remove_anki_redesign_class, 0)
             """
     # script on the beginning of the HTML so it will always be
     # before any user-defined, potentially malformed HTML


### PR DESCRIPTION
Hey!

Great job with the add-on first of all! I just gave it a try and it seems to be working well.

I noticed that Review Heatmap would display its night mode theme with Redesign active. That's because Review Heatmap uses the `night_mode` CSS selector to apply the corresponding theme. I think there are a few other add-ons that do the same.

This PR simply replaces that class with `anki_redesign` for now in order to prevent themeing inconsistencies with third-party add-ons. Further adjustments might be necessary for add-ons that change their Qt style depending on the presence of Night Mode, but I did not look into that further.

I think you were talking about potentially expanding the add-on with a dark version of the theme in the future, so at some point it might make sense to conditionally reintroduce `night_mode` when the dark theme is active.